### PR TITLE
Move watchdog to seperate container

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__/
+.mypy_cache/
+venv/

--- a/backend/Dockerfile.watch
+++ b/backend/Dockerfile.watch
@@ -4,4 +4,6 @@ ADD requirements.txt .
 RUN pip install -r requirements.txt
 ADD gunicorn.conf.py .
 ADD scoreboard/ scoreboard/
-ENTRYPOINT ["gunicorn", "scoreboard:app"]
+ADD watch_entrypoint.sh .
+RUN chmod +x watch_entrypoint.sh
+ENTRYPOINT ["/service/watch_entrypoint.sh"]

--- a/backend/Dockerfile.watch
+++ b/backend/Dockerfile.watch
@@ -1,9 +1,0 @@
-FROM python:3-slim
-WORKDIR /service
-ADD requirements.txt .
-RUN pip install -r requirements.txt
-ADD gunicorn.conf.py .
-ADD scoreboard/ scoreboard/
-ADD watch_entrypoint.sh .
-RUN chmod +x watch_entrypoint.sh
-ENTRYPOINT ["/service/watch_entrypoint.sh"]

--- a/backend/scoreboard/__init__.py
+++ b/backend/scoreboard/__init__.py
@@ -1,1 +1,1 @@
-from .main import app
+from .app import app

--- a/backend/scoreboard/app.py
+++ b/backend/scoreboard/app.py
@@ -1,78 +1,16 @@
 import asyncio
 import json
-import os
 from typing import Any, Dict, List, Optional
 
-import aredis
 from fastapi import FastAPI, HTTPException, status
 from fastapi.responses import Response
-from pydantic import BaseModel
-from watchgod import Change, awatch
+
+from .common import current_round, redis
+from .models import TeamState
 
 app = FastAPI()
-REDIS_HOST = os.getenv("REDIS_HOST", "127.0.0.1")
-DATA_DIR = os.getenv("DATA_DIR", "../data")
-redis: aredis.StrictRedis = aredis.StrictRedis(host=REDIS_HOST)
 UPDATE_EVENT: asyncio.Event = asyncio.Event()
 scoreboard_cache: Dict[int, bytes] = dict()
-
-
-class ServiceDetail(BaseModel):
-    ServiceId: int
-    AttackPoints: float
-    LostDefensePoints: float
-    ServiceLevelAgreementPoints: float
-    ServiceStatus: str
-    Message: str
-
-
-class ScoreboardTeam(BaseModel):
-    Name: str
-    TeamId: int
-    TotalPoints: float
-    AttackPoints: float
-    LostDefensePoints: float
-    ServiceLevelAgreementPoints: float
-    ServiceDetails: List[ServiceDetail]
-
-
-class FirstBlood(BaseModel):
-    TeamId: int
-    Timestamp: str
-    RoundId: int
-    StoreDescription: Optional[str]
-    StoreIndex: int
-
-
-class ScoreboardService(BaseModel):
-    ServiceId: int
-    ServiceName: str
-    MaxStores: int
-    FirstBloods: List[FirstBlood]
-
-
-class JsonScoreboard(BaseModel):
-    CurrentRound: Optional[int]
-    StartTimeEpoch: Optional[int]
-    EndTimeEpoch: Optional[int]
-    Services: List[ScoreboardService]
-    Teams: List[ScoreboardTeam]
-
-
-class TeamState(BaseModel):
-    Round: int
-    TotalPoints: float
-    AttackPoints: float
-    LostDefensePoints: float
-    ServiceLevelAgreementPoints: float
-    ServiceDetails: List[ServiceDetail]
-
-
-async def current_round() -> Optional[int]:
-    r = await redis.get("max_round")
-    if not r:
-        return None
-    return int(r.decode())
 
 
 async def get_scoreboard(round: Optional[int] = None) -> Optional[bytes]:
@@ -188,53 +126,7 @@ async def get_team(team_id: int) -> Response:
 
 @app.on_event("startup")
 async def startup() -> None:
-    base_path = os.path.join(DATA_DIR, "scoreboard.json")
-    await parse_scoreboard(base_path)
-    r = await current_round()
-    if r is not None:
-        for i in range(0, r + 1):
-            sb_path = os.path.join(DATA_DIR, f"scoreboard{i}.json")
-            await parse_scoreboard(sb_path)
-
-    asyncio.create_task(create_watch())
     asyncio.create_task(handle_updates())
-
-
-async def create_watch() -> None:
-    async for changes in awatch(DATA_DIR):
-        for c in changes:
-            if c[0] == Change.added or c[0] == Change.modified:
-                await parse_scoreboard(c[1])
-
-
-async def parse_scoreboard(file_: str) -> None:
-    basename = os.path.basename(file_)
-    if not basename.startswith("scoreboard") or not basename.endswith(".json"):
-        return
-    try:
-        obj = json.load(open(file_, "r"))
-        sb = JsonScoreboard(**obj)
-        print(f"Loading scoreboard for round {sb.CurrentRound}")
-
-        if not sb.CurrentRound:
-            return
-
-        entry = await redis.get(f"sb_{sb.CurrentRound}")
-        if not entry:
-            await redis.set(f"sb_{sb.CurrentRound}", sb.json())
-
-        entry = await redis.get("max_round")
-        print(f"previous: max_round: {entry}")
-        if not entry or int(entry.decode()) < sb.CurrentRound:
-            await redis.set("max_round", sb.CurrentRound)
-            await redis.publish("notifications", sb.CurrentRound)
-
-        for t in sb.Teams:
-            await redis.set(f"team_exists_${t.TeamId}", True)
-    except FileNotFoundError as e:
-        print(f"Failed to load scoreboard: {file_}, {str(e)}")
-    except json.JSONDecodeError as e:
-        print(f"Failed to parse scoreboard: {file_}, {str(e)}")
 
 
 async def handle_updates() -> None:

--- a/backend/scoreboard/common.py
+++ b/backend/scoreboard/common.py
@@ -1,0 +1,14 @@
+import os
+from typing import Optional
+
+import aredis
+
+REDIS_HOST = os.getenv("REDIS_HOST", "127.0.0.1")
+redis: aredis.StrictRedis = aredis.StrictRedis(host=REDIS_HOST)
+
+
+async def current_round() -> Optional[int]:
+    r = await redis.get("max_round")
+    if not r:
+        return None
+    return int(r.decode())

--- a/backend/scoreboard/models.py
+++ b/backend/scoreboard/models.py
@@ -1,0 +1,54 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class ServiceDetail(BaseModel):
+    ServiceId: int
+    AttackPoints: float
+    LostDefensePoints: float
+    ServiceLevelAgreementPoints: float
+    ServiceStatus: str
+    Message: str
+
+
+class ScoreboardTeam(BaseModel):
+    Name: str
+    TeamId: int
+    TotalPoints: float
+    AttackPoints: float
+    LostDefensePoints: float
+    ServiceLevelAgreementPoints: float
+    ServiceDetails: List[ServiceDetail]
+
+
+class FirstBlood(BaseModel):
+    TeamId: int
+    Timestamp: str
+    RoundId: int
+    StoreDescription: Optional[str]
+    StoreIndex: int
+
+
+class ScoreboardService(BaseModel):
+    ServiceId: int
+    ServiceName: str
+    MaxStores: int
+    FirstBloods: List[FirstBlood]
+
+
+class JsonScoreboard(BaseModel):
+    CurrentRound: Optional[int]
+    StartTimeEpoch: Optional[int]
+    EndTimeEpoch: Optional[int]
+    Services: List[ScoreboardService]
+    Teams: List[ScoreboardTeam]
+
+
+class TeamState(BaseModel):
+    Round: int
+    TotalPoints: float
+    AttackPoints: float
+    LostDefensePoints: float
+    ServiceLevelAgreementPoints: float
+    ServiceDetails: List[ServiceDetail]

--- a/backend/scoreboard/watch.py
+++ b/backend/scoreboard/watch.py
@@ -10,7 +10,7 @@ from .models import JsonScoreboard
 DATA_DIR = os.getenv("DATA_DIR", "../data")
 
 
-async def test() -> None:
+async def main() -> None:
     base_path = os.path.join(DATA_DIR, "scoreboard.json")
     await parse_scoreboard(base_path)
     r = await current_round()
@@ -63,4 +63,4 @@ async def parse_scoreboard(file_: str) -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(test())
+    asyncio.run(main())

--- a/backend/scoreboard/watch.py
+++ b/backend/scoreboard/watch.py
@@ -1,0 +1,68 @@
+print("lol")
+
+import asyncio
+import json
+import os
+
+from watchgod import Change, awatch
+
+from .common import current_round, redis
+from .models import JsonScoreboard
+
+DATA_DIR = os.getenv("DATA_DIR", "../data")
+
+
+async def test() -> None:
+    base_path = os.path.join(DATA_DIR, "scoreboard.json")
+    await parse_scoreboard(base_path)
+    r = await current_round()
+    if r is not None:
+        for i in range(0, r + 1):
+            sb_path = os.path.join(DATA_DIR, f"scoreboard{i}.json")
+            await parse_scoreboard(sb_path)
+    else:
+        print("no pre-existing scoreboard files found")
+
+    print(f"watching {DATA_DIR}")
+    async for changes in awatch(DATA_DIR):
+        for c in changes:
+            if c[0] == Change.added or c[0] == Change.modified:
+                await parse_scoreboard(c[1])
+            else:
+                print(f"ignoring change: {c}")
+
+
+async def parse_scoreboard(file_: str) -> None:
+    basename = os.path.basename(file_)
+    if not basename.startswith("scoreboard") or not basename.endswith(".json"):
+        print(f"skipping {file_}")
+        return
+    print(f"parsing {file_}")
+    try:
+        obj = json.load(open(file_, "r"))
+        sb = JsonScoreboard(**obj)
+        print(f"Loading scoreboard for round {sb.CurrentRound}")
+
+        if not sb.CurrentRound:
+            return
+
+        entry = await redis.get(f"sb_{sb.CurrentRound}")
+        if not entry:
+            await redis.set(f"sb_{sb.CurrentRound}", sb.json())
+
+        entry = await redis.get("max_round")
+        print(f"previous: max_round: {entry}")
+        if not entry or int(entry.decode()) < sb.CurrentRound:
+            await redis.set("max_round", sb.CurrentRound)
+            await redis.publish("notifications", sb.CurrentRound)
+
+        for t in sb.Teams:
+            await redis.set(f"team_exists_${t.TeamId}", True)
+    except FileNotFoundError as e:
+        print(f"Failed to load scoreboard: {file_}, {str(e)}")
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse scoreboard: {file_}, {str(e)}")
+
+
+if __name__ == "__main__":
+    asyncio.run(test())

--- a/backend/scoreboard/watch.py
+++ b/backend/scoreboard/watch.py
@@ -1,5 +1,3 @@
-print("lol")
-
 import asyncio
 import json
 import os

--- a/backend/watch_entrypoint.sh
+++ b/backend/watch_entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Starting scoreboard.watch ..."
+python3 -c 'print("test"); import scoreboard.watch as m; print(m); from scoreboard.watch import test; import asyncio; asyncio.run(test())'
+python3 -m scoreboard.watch

--- a/backend/watch_entrypoint.sh
+++ b/backend/watch_entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-echo "Starting scoreboard.watch ..."
-python3 -c 'print("test"); import scoreboard.watch as m; print(m); from scoreboard.watch import test; import asyncio; asyncio.run(test())'
-python3 -m scoreboard.watch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,16 +12,16 @@ services:
         soft: 20000
         hard: 40000
   scoreboard_watch:
-    build:
-      context: backend
-      dockerfile: Dockerfile.watch
+    build: backend
     environment:
       - REDIS_HOST=redis
       - DATA_DIR=/data
+      - PYTHONUNBUFFERED=1
     volumes:
-      - ./services/data:/data
+      - /services/data:/data
     depends_on:
       - redis
+    entrypoint: ["python", "-m", "scoreboard.watch"]
   redis:
     image: redis
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,23 @@ services:
     build: backend
     environment:
       - REDIS_HOST=redis
-      - DATA_DIR=/data
     volumes:
-      - /services/data:/data
       - ./sock:/var/run/gunicorn:rw
     ulimits:
       nofile:
         soft: 20000
         hard: 40000
+  scoreboard_watch:
+    build:
+      context: backend
+      dockerfile: Dockerfile.watch
+    environment:
+      - REDIS_HOST=redis
+      - DATA_DIR=/data
+    volumes:
+      - ./services/data:/data
+    depends_on:
+      - redis
   redis:
     image: redis
   nginx:


### PR DESCRIPTION
This resolves a bug where gunicorn kept killing the workers at startup because the initial file system can took too long. Simply putting this inside a background task would not be an option, because each worker would still scan all of the `.json` files once, instead of scanning them one time total.